### PR TITLE
URL Cleanup

### DIFF
--- a/themes/github-project-landing-page/exampleSite/content/img/intro-bg.svg
+++ b/themes/github-project-landing-page/exampleSite/content/img/intro-bg.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="500px" height="500px" viewBox="0 0 500 500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.4.2 (15857) - http://www.bohemiancoding.com/sketch -->
+<svg width="500px" height="500px" viewBox="0 0 500 500" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="https://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.4.2 (15857) - https://www.bohemiancoding.com/sketch -->
     <title>app-icon-board</title>
     <desc>Created with Sketch.</desc>
     <defs>

--- a/themes/github-project-landing-page/static/fonts/glyphicons-halflings-regular.svg
+++ b/themes/github-project-landing-page/static/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://www.bohemiancoding.com/sketch with 1 occurrences migrated to:  
  https://www.bohemiancoding.com/sketch ([https](https://www.bohemiancoding.com/sketch) result 302).
* [ ] http://www.bohemiancoding.com/sketch/ns with 1 occurrences migrated to:  
  https://www.bohemiancoding.com/sketch/ns ([https](https://www.bohemiancoding.com/sketch/ns) result 302).

# Ignored
These URLs were intentionally ignored.

* http://www.w3.org/1999/xlink with 2 occurrences
* http://www.w3.org/2000/svg with 3 occurrences