### PR TITLE
Clarified the limitation of deploying to Windows OS of PWS and PCF Dev.

### DIFF
--- a/source/docs/steeltoe-introduction.html.markdown
+++ b/source/docs/steeltoe-introduction.html.markdown
@@ -50,7 +50,7 @@ For the Quick Starts in which we run the application locally, Java is required t
 
 For the Quick Starts running on Cloud Foundry, you need access to a Cloud Foundry environment that has the appropriate services (such as Spring Cloud Config Server, Netflix Eureka Server, and others) installed. One option is to run [PCF Dev](https://docs.pivotal.io/pcf-dev/), the local developer version of Pivotal Cloud Foundry on your development machine. PCF Dev depends on Virtual Box, so, depending on your desktop operating system and configuration, you may not be able to use it.
 
-Alternatively, you can sign up for a free trial account of [Pivotal Web Services](https://run.pivotal.io/), the hosted multi-tenant edition of [Pivotal Cloud Foundry](https://pivotal.io/platform). Note that, if you want to work solely with .NET framework applications that target the Windows operating system, you likely need access to a corporate Cloud Foundry environment, as neither of the above options currently support deploying Windows apps.
+Alternatively, you can sign up for a free trial account of [Pivotal Web Services](https://run.pivotal.io/), the hosted multi-tenant edition of [Pivotal Cloud Foundry](https://pivotal.io/platform). Note that, if you want to work solely with .NET framework applications that target the Windows operating system, you likely need access to a corporate Cloud Foundry environment, as neither of the above options currently support deploying to the the Windows operating system.
 
 Regardless of which Cloud Foundry option you choose, in order to work with Cloud Foundry, you need to install the [Cloud Foundry Command Line Interface (CLI)](https://github.com/cloudfoundry/cli/releases).
 

--- a/source/docs/steeltoe-introduction.html.markdown
+++ b/source/docs/steeltoe-introduction.html.markdown
@@ -50,7 +50,7 @@ For the Quick Starts in which we run the application locally, Java is required t
 
 For the Quick Starts running on Cloud Foundry, you need access to a Cloud Foundry environment that has the appropriate services (such as Spring Cloud Config Server, Netflix Eureka Server, and others) installed. One option is to run [PCF Dev](https://docs.pivotal.io/pcf-dev/), the local developer version of Pivotal Cloud Foundry on your development machine. PCF Dev depends on Virtual Box, so, depending on your desktop operating system and configuration, you may not be able to use it.
 
-Alternatively, you can sign up for a free trial account of [Pivotal Web Services](https://run.pivotal.io/), the hosted multi-tenant edition of [Pivotal Cloud Foundry](https://pivotal.io/platform). Note that, if you want to work solely with .NET framework applications that target the Windows operating system, you likely need access to a corporate Cloud Foundry environment, as neither of the above options currently support deploying to the the Windows operating system.
+Alternatively, you can sign up for a free trial account of [Pivotal Web Services](https://run.pivotal.io/), the hosted multi-tenant edition of [Pivotal Cloud Foundry](https://pivotal.io/platform). Note that, if you want to work solely with .NET framework applications that target the Windows operating system, you likely need access to a corporate Cloud Foundry environment, as neither of the above options currently support deploying to the Windows operating system.
 
 Regardless of which Cloud Foundry option you choose, in order to work with Cloud Foundry, you need to install the [Cloud Foundry Command Line Interface (CLI)](https://github.com/cloudfoundry/cli/releases).
 


### PR DESCRIPTION
The current documentation could be interpreted as saying that the deployment of Windows applications is not supported at all. However, the deployment of Windows “core” applications is supported to the Linux OS.